### PR TITLE
chore(startup): set MESA_LOADER_DRIVER_OVERRIDE=zink for nvidia cards

### DIFF
--- a/com.jagex.Launcher.yaml
+++ b/com.jagex.Launcher.yaml
@@ -176,6 +176,10 @@ modules:
 
           set -exuo pipefail
 
+          if [ -f /proc/driver/nvidia/version ]; then
+              export MESA_LOADER_DRIVER_OVERRIDE=zink
+          fi
+
           WINEDIR=/app/wine/bin
 
           mkdir -p "${WINEPREFIX}/drive_c/Program Files (x86)/"


### PR DESCRIPTION
Should close #126 while avoiding #16 which looked to be specific to AMD cards
